### PR TITLE
HT Automatic Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If you want to display full-text links to *any* HathiTrust record, regardless of
 <hathi-trust-availability ignore-copyright="true"></hathi-trust-availability>
 ```
 
+If you're a partner institution and you want the availability links to use HathiTrust's [automatic login](https://www.hathitrust.org/automatic_login), add your SAML IdP's entity ID:
+
+```html
+<hathi-trust-availability 
+    ignore-copyright="true" 
+    entity-id="https://shibboleth.umich.edu/idp/shibboleth"
+></hathi-trust-availability>
+```
 
 ## Running tests
 1. Clone the repo

--- a/js/custom.module.js
+++ b/js/custom.module.js
@@ -2,7 +2,9 @@
  * This is only used to for testing/development
  * (see the npm start script).
  */
-angular.module('viewCustom', ['hathiTrustAvailability'])
-  .component('prmSearchResultAvailabilityLineAfter', {
-    template: '<hathi-trust-availability ignore-copyright="true"></hathi-trust-availability>'
+angular
+  .module("viewCustom", ["hathiTrustAvailability"])
+  .component("prmSearchResultAvailabilityLineAfter", {
+    template:
+      '<hathi-trust-availability ignore-copyright="true" entity-id="urn:mace:incommon:umn.edu"></hathi-trust-availability>'
   });

--- a/js/hathi-trust-availability.module.js
+++ b/js/hathi-trust-availability.module.js
@@ -16,11 +16,11 @@ angular
   .factory("hathiTrust", [
     "$http",
     "$q",
-    function($http, $q) {
+    "hathiTrustBaseUrl",
+    function($http, $q, hathiTrustBaseUrl) {
       var svc = {};
-      var hathiTrustBaseUrl =
-        "https://catalog.hathitrust.org/api/volumes/brief/json/";
-      var lookup = function(ids, callback) {
+
+      var lookup = function(ids) {
         if (ids.length) {
           var hathiTrustLookupUrl = hathiTrustBaseUrl + ids.join("|");
           return $http
@@ -104,21 +104,21 @@ angular
         );
       };
 
+      var formatLink = function(link) {
+        return self.entityId ? link + "?signon=swle:" + self.entityId : link;
+      };
+
       var updateHathiTrustAvailability = function() {
         var hathiTrustIds = (
           self.prmSearchResultAvailabilityLine.result.pnx.addata.oclcid || []
         ).map(function(id) {
           return "oclc:" + id;
         });
-        if (self.ignoreCopyright) {
-          hathiTrust.findRecord(hathiTrustIds).then(function(res) {
-            self.fullTextLink = res;
-          });
-        } else {
-          hathiTrust.findFullViewRecord(hathiTrustIds).then(function(res) {
-            self.fullTextLink = res;
-          });
-        }
+        hathiTrust[self.ignoreCopyright ? "findRecord" : "findFullViewRecord"](
+          hathiTrustIds
+        ).then(function(res) {
+          if (res) self.fullTextLink = formatLink(res);
+        });
       };
     }
   ])
@@ -127,6 +127,7 @@ angular
       prmSearchResultAvailabilityLine: "^prmSearchResultAvailabilityLine"
     },
     bindings: {
+      entityId: "@",
       ignoreCopyright: "<",
       hideOnline: "<",
       msg: "@?"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primo-explore-hathitrust-availability",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Adds HathiTrust links to Primo search results",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "angular": "1.6.3",
-    "angular-mocks": "1.6.3",
+    "angular": "^1.6.3",
+    "angular-mocks": "^1.6.3",
     "angular-ui-router": "^1.0.0-beta.2",
     "babel-preset-es2015": "6.6.0",
     "gulp": "3.5.2",

--- a/test/hathi-trust-availability.controller.spec.js
+++ b/test/hathi-trust-availability.controller.spec.js
@@ -1,95 +1,147 @@
-describe('hathiTrustAvailabilityController', function(){
-
-  beforeEach(module('hathiTrustAvailability'));
-  var $componentController, $rootScope, $q, hathiTrust, ctrl, prmSearchResultAvailabilityLine, expectedIds, bindings;
-
+describe("hathiTrustAvailabilityController", function() {
+  beforeEach(module("hathiTrustAvailability"));
+  var $componentController,
+    $rootScope,
+    $q,
+    hathiTrust,
+    ctrl,
+    prmSearchResultAvailabilityLine,
+    expectedIds,
+    bindings;
   var myIconSrc = "my/icon/file.svg";
   beforeEach(function() {
     module(function($provide) {
-      $provide.value('hathiTrustIconPath', myIconSrc);
+      $provide.value("hathiTrustIconPath", myIconSrc);
     });
   });
 
-  beforeEach(inject(function(_$componentController_, _$rootScope_, _hathiTrust_, $injector){
+  beforeEach(inject(function(
+    _$componentController_,
+    _$rootScope_,
+    _hathiTrust_,
+    $injector
+  ) {
     $componentController = _$componentController_;
     $rootScope = _$rootScope_;
     hathiTrust = _hathiTrust_;
-    $timeout = $injector.get('$timeout');
-    $q = $injector.get('$q');
+    $timeout = $injector.get("$timeout");
+    $q = $injector.get("$q");
     expectedIds = ["oclc:1586310", "oclc:7417753", "oclc:47076528"];
     prmSearchResultAvailabilityLine = {};
-    prmSearchResultAvailabilityLine.result = getJSONFixture('print_result.json');
-    bindings = {hathiTrust: hathiTrust, 
-                prmSearchResultAvailabilityLine: prmSearchResultAvailabilityLine};
-
+    prmSearchResultAvailabilityLine.result = getJSONFixture(
+      "print_result.json"
+    );
+    bindings = {
+      hathiTrust: hathiTrust,
+      prmSearchResultAvailabilityLine: prmSearchResultAvailabilityLine
+    };
   }));
 
-  it('should pass the OCLC numbers to the hathiTrust service', function(){
-    spyOn(hathiTrust, 'findFullViewRecord').and.
-      returnValue({then: function(callback){ return callback(true)}});
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+  it("should pass the OCLC numbers to the hathiTrust service", function() {
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).toHaveBeenCalledWith(expectedIds);
   });
 
-  it('should update the hathiTrustFullText link if available', function(){
+  it("should update the hathiTrustFullText link if available", function() {
     var link = "http://example.com";
-    spyOn(hathiTrust, 'findFullViewRecord').and.
-      returnValue({then: function(callback){ return callback(link)}});
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(link);
+      }
+    });
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(ctrl.fullTextLink).toBe(link);
   });
 
-  it('should not call the hathTrust service for online resoureces when disabled', function(){
-    prmSearchResultAvailabilityLine.result = getJSONFixture('online_result.json');
-    spyOn(hathiTrust, 'findFullViewRecord').and.
-      returnValue({then: function(callback){ return callback(true)}});
+  it("should not call the hathTrust service for online resoureces when disabled", function() {
+    prmSearchResultAvailabilityLine.result = getJSONFixture(
+      "online_result.json"
+    );
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
 
     bindings.hideOnline = true;
 
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
-   });
+  });
 
-  it('should call the hathTrust service for online resoureces by default', function(){
-    prmSearchResultAvailabilityLine.result = getJSONFixture('online_result.json');
-    spyOn(hathiTrust, 'findFullViewRecord').and.
-      returnValue({then: function(callback){ return callback(true)}});
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+  it("should call the hathTrust service for online resoureces by default", function() {
+    prmSearchResultAvailabilityLine.result = getJSONFixture(
+      "online_result.json"
+    );
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).toHaveBeenCalled();
   });
 
-  it('should accept a custom availability message', function(){
+  it("should accept a custom availability message", function() {
     var myMsg = "FULL TEXT FROM HATHITRUST, YAY!";
     bindings.msg = myMsg;
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(ctrl.msg).toBe(myMsg);
   });
 
-  it('should use a default availability message when not provided', function(){
-    var expectedDefaultMsg = 'Full Text Available at HathiTrust';
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+  it("should use a default availability message when not provided", function() {
+    var expectedDefaultMsg = "Full Text Available at HathiTrust";
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(ctrl.msg).toBe(expectedDefaultMsg);
   });
 
-  it('should call hathiTrust.findRecord() when ignoreCopyright=true', function(){
-    prmSearchResultAvailabilityLine.result = getJSONFixture('online_result.json');
-    spyOn(hathiTrust, 'findFullViewRecord').and.
-      returnValue({then: function(callback){ return callback(true)}});
-    spyOn(hathiTrust, 'findRecord').and.
-      returnValue({then: function(callback){ return callback(true)}});
+  it("should call hathiTrust.findRecord() when ignoreCopyright=true", function() {
+    prmSearchResultAvailabilityLine.result = getJSONFixture(
+      "online_result.json"
+    );
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
+    spyOn(hathiTrust, "findRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
 
     bindings.ignoreCopyright = true;
 
-    ctrl = $componentController('hathiTrustAvailability', null, bindings);
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
     expect(hathiTrust.findRecord).toHaveBeenCalled();
-   });
+  });
 
+  it("should append an 'signon' parameter when an entityId is defined", function() {
+    var link = "http://example.com";
+    var entityId = "https://example.edu/idp/shibboleth";
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(link);
+      }
+    });
+
+    bindings.entityId = entityId;
+
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
+    ctrl.$onInit();
+    expect(ctrl.fullTextLink).toBe(link + "?signon=swle:" + entityId);
+  });
 });


### PR DESCRIPTION
Added an `entity-id` property that enables partner institutions to use HathiTrust's "automatic login" feature with availability links (See https://www.hathitrust.org/automatic_login). 

Example: 
```html
<hathi-trust-availability 
    ignore-copyright="true" 
    entity-id="https://shibboleth.umich.edu/idp/shibboleth"
></hathi-trust-availability>
```
