### PR TITLE
feature: add 'hide-if-journal' option 

### DIFF
--- a/js/hathi-trust-availability.module.js
+++ b/js/hathi-trust-availability.module.js
@@ -85,13 +85,24 @@ angular
 
       self.$onInit = function() {
         setDefaults();
-        if (!(isOnline() && self.hideOnline)) {
-          updateHathiTrustAvailability();
-        }
+
+        // prevent appearance/request iff 'hide-online' 
+        if (isOnline() && self.hideOnline) { return; }
+
+        // prevent appearance/request iff 'hide-if-journal'
+        if(isJournal() && self.hideIfJournal){ return; }
+
+        // look for full text at HathiTrust 
+        updateHathiTrustAvailability();
       };
 
       var setDefaults = function() {
         if (!self.msg) self.msg = "Full Text Available at HathiTrust";
+      };
+
+      var isJournal = function() {
+        var format =  self.prmSearchResultAvailabilityLine.result.pnx.addata.format[0];
+        return format.toLowerCase().includes("journal");
       };
 
       var isOnline = function() {
@@ -129,6 +140,7 @@ angular
     bindings: {
       entityId: "@",
       ignoreCopyright: "<",
+      hideIfJournal: "<",
       hideOnline: "<",
       msg: "@?"
     },

--- a/js/hathi-trust-availability.module.js
+++ b/js/hathi-trust-availability.module.js
@@ -90,7 +90,7 @@ angular
         if (isOnline() && self.hideOnline) { return; }
 
         // prevent appearance/request iff 'hide-if-journal'
-        if(isJournal() && self.hideIfJournal){ return; }
+        if (isJournal() && self.hideIfJournal){ return; }
 
         // look for full text at HathiTrust 
         updateHathiTrustAvailability();
@@ -102,7 +102,7 @@ angular
 
       var isJournal = function() {
         var format =  self.prmSearchResultAvailabilityLine.result.pnx.addata.format[0];
-        return format.toLowerCase().includes("journal");
+        return !(format.toLowerCase().indexOf("journal") == -1); // format.includes("Journal")
       };
 
       var isOnline = function() {

--- a/test/hathi-trust-availability.controller.spec.js
+++ b/test/hathi-trust-availability.controller.spec.js
@@ -60,43 +60,19 @@ describe("hathiTrustAvailabilityController", function() {
     expect(ctrl.fullTextLink).toBe(link);
   });
 
-  it("should call the hathiTrust service for non-journals, even when 'hide-if-journal'", function() {
-    
-    // set conditions such that 'hide-if-journal' is true, but the item format is not a journal
-    prmSearchResultAvailabilityLine.result = getJSONFixture("online_result.json");
-    prmSearchResultAvailabilityLine.result.pnx.addata.format[0] = 'book'; 
-    bindings.hideIfJournal = true;
-    
+  it("should call the hathTrust service for online resoureces by default", function() {
+    prmSearchResultAvailabilityLine.result = getJSONFixture(
+      "online_result.json"
+    );
     spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
       then: function(callback) {
         return callback(true);
       }
     });
-    
-
     ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).toHaveBeenCalled();
   });
-
-  it("should not call the hathiTrust service for journals when 'hide-if-journal'", function() {
-    
-    // set conditions such that 'hide-if-journal' is true AND the item format is journal
-    prmSearchResultAvailabilityLine.result = getJSONFixture("online_result.json");
-    prmSearchResultAvailabilityLine.result.pnx.addata.format[0] = 'journal'; 
-    bindings.hideIfJournal = true;
-    
-    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
-      then: function(callback) {
-        return callback(true);
-      }
-    });    
-
-    ctrl = $componentController("hathiTrustAvailability", null, bindings);
-    ctrl.$onInit();
-    expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
-  });
-
 
   it("should not call the hathiTrust service for online resoureces when disabled", function() {
     prmSearchResultAvailabilityLine.result = getJSONFixture(
@@ -115,18 +91,41 @@ describe("hathiTrustAvailabilityController", function() {
     expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
   });
 
-  it("should call the hathTrust service for online resoureces by default", function() {
-    prmSearchResultAvailabilityLine.result = getJSONFixture(
-      "online_result.json"
-    );
+  it("should call the hathiTrust service for non-journals, when 'hide-if-journal'", function() {
+    
+    // set conditions such that 'hide-if-journal' is true BUT the item format is not a journal
+    prmSearchResultAvailabilityLine.result = getJSONFixture("online_result.json");
+    prmSearchResultAvailabilityLine.result.pnx.addata.format[0] = 'book'; 
+    bindings.hideIfJournal = true;
+    
     spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
       then: function(callback) {
         return callback(true);
       }
     });
+    
+
     ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).toHaveBeenCalled();
+  });
+
+  it("should not call the hathiTrust service for journals when 'hide-if-journal'", function() {
+    
+    // set conditions such that 'hide-if-journal' is true AND the item format is a journal
+    prmSearchResultAvailabilityLine.result = getJSONFixture("online_result.json");
+    prmSearchResultAvailabilityLine.result.pnx.addata.format[0] = 'journal'; 
+    bindings.hideIfJournal = true;
+    
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });    
+
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
+    ctrl.$onInit();
+    expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
   });
 
   it("should accept a custom availability message", function() {

--- a/test/hathi-trust-availability.controller.spec.js
+++ b/test/hathi-trust-availability.controller.spec.js
@@ -60,7 +60,32 @@ describe("hathiTrustAvailabilityController", function() {
     expect(ctrl.fullTextLink).toBe(link);
   });
 
-  it("should not call the hathTrust service for online resoureces when disabled", function() {
+  it("should not call the hathiTrust service for journals when 'hide-if-journal'", function() {
+    prmSearchResultAvailabilityLine.result = getJSONFixture(
+      "online_result.json"  // NOTE: pnx.addata.format[0] for this is already 'journal'
+    );
+
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
+    spyOn(hathiTrust, "findRecord").and.returnValue({
+      then: function(callback) {
+        return callback(true);
+      }
+    });
+
+    bindings.hideIfJournal = true;
+
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
+    ctrl.$onInit();
+    expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
+    expect(hathiTrust.findRecord).not.toHaveBeenCalled();
+  });
+
+
+  it("should not call the hathiTrust service for online resoureces when disabled", function() {
     prmSearchResultAvailabilityLine.result = getJSONFixture(
       "online_result.json"
     );

--- a/test/hathi-trust-availability.controller.spec.js
+++ b/test/hathi-trust-availability.controller.spec.js
@@ -60,28 +60,41 @@ describe("hathiTrustAvailabilityController", function() {
     expect(ctrl.fullTextLink).toBe(link);
   });
 
-  it("should not call the hathiTrust service for journals when 'hide-if-journal'", function() {
-    prmSearchResultAvailabilityLine.result = getJSONFixture(
-      "online_result.json"  // NOTE: pnx.addata.format[0] for this is already 'journal'
-    );
-
+  it("should call the hathiTrust service for non-journals, even when 'hide-if-journal'", function() {
+    
+    // set conditions such that 'hide-if-journal' is true, but the item format is not a journal
+    prmSearchResultAvailabilityLine.result = getJSONFixture("online_result.json");
+    prmSearchResultAvailabilityLine.result.pnx.addata.format[0] = 'book'; 
+    bindings.hideIfJournal = true;
+    
     spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
       then: function(callback) {
         return callback(true);
       }
     });
-    spyOn(hathiTrust, "findRecord").and.returnValue({
+    
+
+    ctrl = $componentController("hathiTrustAvailability", null, bindings);
+    ctrl.$onInit();
+    expect(hathiTrust.findFullViewRecord).toHaveBeenCalled();
+  });
+
+  it("should not call the hathiTrust service for journals when 'hide-if-journal'", function() {
+    
+    // set conditions such that 'hide-if-journal' is true AND the item format is journal
+    prmSearchResultAvailabilityLine.result = getJSONFixture("online_result.json");
+    prmSearchResultAvailabilityLine.result.pnx.addata.format[0] = 'journal'; 
+    bindings.hideIfJournal = true;
+    
+    spyOn(hathiTrust, "findFullViewRecord").and.returnValue({
       then: function(callback) {
         return callback(true);
       }
-    });
-
-    bindings.hideIfJournal = true;
+    });    
 
     ctrl = $componentController("hathiTrustAvailability", null, bindings);
     ctrl.$onInit();
     expect(hathiTrust.findFullViewRecord).not.toHaveBeenCalled();
-    expect(hathiTrust.findRecord).not.toHaveBeenCalled();
   });
 
 


### PR DESCRIPTION
### Background 
- the HathiTrust record entry for journals is slightly different than those of books or articles, since coverage or availability for particular items within it might be partial or hard to interpret for users
- we (Boston University Libraries) wanted to prevent this difficulty for our users by preventing this availability line from showing up on _journals_, but keeping the functionality for books and articles.

### Description of Changes
- add a `hide-if-journal` property (similar to `hide-online`) and an `isJournal` helper that checks the `item.pnx.addata.format`
- if it's present and the item is a journal, prevent the call to `updateHathiTrustAvailability()` that prepares the link

### Screenshot
screenshot showing the new availability line appearing for books, but not journals
![screenshot showing it appearing for books, but not journals](https://user-images.githubusercontent.com/5565284/78593038-fa767380-7813-11ea-916c-caac01bc7d68.png)
