### PR TITLE
Hide links if unavailable locally

### DIFF
--- a/js/hathi-trust-availability.module.js
+++ b/js/hathi-trust-availability.module.js
@@ -97,6 +97,11 @@ angular
           return;
         }
 
+    	// prevent appearance/request if item is unavailable
+    	if (self.ignoreCopyright && !isAvailable()) {
+ 	  return;
+    	}
+
         // look for full text at HathiTrust
         updateHathiTrustAvailability();
       };
@@ -105,6 +110,12 @@ angular
         var format =
           self.prmSearchResultAvailabilityLine.result.pnx.addata.format[0];
         return !(format.toLowerCase().indexOf('journal') == -1); // format.includes("Journal")
+      };
+
+      var isAvailable = function isAvailable() {
+	var available = self.prmSearchResultAvailabilityLine.result.delivery.availability[0];
+	console.log(self.prmSearchResultAvailabilityLine.result.delivery.availability);
+	return (available.toLowerCase().indexOf('unavailable') == -1); 
       };
 
       var isOnline = function () {

--- a/js/hathi-trust-availability.module.js
+++ b/js/hathi-trust-availability.module.js
@@ -99,8 +99,9 @@ angular
 
     	// prevent appearance/request if item is unavailable
     	if (self.ignoreCopyright && !isAvailable()) {
- 	  return;
-    	}
+    	   //allow links for locally unavailable items that are in the public domain
+           self.ignoreCopyright=false;
+        }
 
         // look for full text at HathiTrust
         updateHathiTrustAvailability();

--- a/js/hathi-trust-availability.module.js
+++ b/js/hathi-trust-availability.module.js
@@ -114,7 +114,6 @@ angular
 
       var isAvailable = function isAvailable() {
 	var available = self.prmSearchResultAvailabilityLine.result.delivery.availability[0];
-	console.log(self.prmSearchResultAvailabilityLine.result.delivery.availability);
 	return (available.toLowerCase().indexOf('unavailable') == -1); 
       };
 


### PR DESCRIPTION
Items in a library catalog may be unavailable due to damage, being lost, or having been checked out since before ETAS began.   If these items could not have been lent out anyway, it calls into question their eligibility for ETAS.  This code stops the display of Hathi Trust links in cases like this, making an exception for those that have copyright-free access through Hathi, separate from ETAS.