### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '10.15.3'
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-deploy:
-  provider: npm
-  email: "$NPM_EMAIL"
-  api_key: "$NPM_TOKEN"
-  on:
-    tags: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # primo-explore-hathitrust-availability
 
-![Build Status](https://api.travis-ci.org/UMNLibraries/primo-explore-hathitrust-availability.svg?branch=master)
-
 ## Features
 When search results are displayed, a record's OCLC numbers are passed to the [HathiTrust Bib API](https://www.hathitrust.org/bib_api). If at least one item with free full-text access is found, a link to the HathiTrust record is appended to the availability section. 
 
@@ -85,7 +83,8 @@ If you're a partner institution and you want the availability links to use Hathi
 * See instructions in [primo-explore-devenv](https://github.com/ExLibrisGroup/primo-explore-devenv) on running locally
 * To deploy: run `gulp create-package` to create a primo compatible package and upload your view in the interface. 
 
-## Running tests
+## Development
+### Running tests
 1. Clone the repo
 2. Run `npm install`
 3. Run `npm test`

--- a/package.json
+++ b/package.json
@@ -16,11 +16,8 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "angular": "^1.6.3",
-    "angular-mocks": "^1.6.3",
-    "angular-ui-router": "^1.0.0-beta.2",
-    "babel-preset-es2015": "6.6.0",
-    "gulp": "3.5.2",
+    "angular": "1.6.10",
+    "angular-mocks": "1.6.10",
     "jasmine-core": "^2.5.1",
     "karma": "^1.3.0",
     "karma-jasmine": "^1.0.2",


### PR DESCRIPTION
Free builds are no longer available on travis-ci.org. Switching CI builds to GitHub Actions instead.